### PR TITLE
fix: don't show entry twice in note files

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,7 +19,7 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npm run integration-test
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report

--- a/src/components/Note.tsx
+++ b/src/components/Note.tsx
@@ -48,7 +48,7 @@ interface NoteComponentProps {
   displayedSlugAliases: string[],
   setDisplayedSlugAliases: (val: string[]) => void,
   handleEditorContentChange: (title: string) => void,
-  addFilesToNoteObject: (responses: FileInfo[]) => void,
+  addFilesToNoteObject: (responses: Set<FileInfo>) => void,
   setUnsavedChanges: (val: boolean) => void,
   handleNoteSaveRequest: () => void,
   removeActiveNote: () => void,
@@ -144,7 +144,7 @@ const Note = ({
     );
 
     setUploadInProgress(false);
-    addFilesToNoteObject(fileInfos);
+    addFilesToNoteObject(new Set(fileInfos));
     return fileInfos;
   };
 

--- a/src/components/NoteStats.tsx
+++ b/src/components/NoteStats.tsx
@@ -64,9 +64,9 @@ const NoteStats = ({
         <tr>
           <td>{l("editor.stats.files")}</td>
           <td>{
-            note.files.length > 0
-              ? note.files
-                .map((file, i, array) => {
+            note.files.size > 0
+              ? note.files.values()
+                .map((file, i) => {
                   const fileType = getMediaTypeFromFilename(file.filename);
 
                   return <Fragment
@@ -78,7 +78,7 @@ const NoteStats = ({
                     <span> </span>
                     ({fileType}, {humanFileSize(file.size)})
                     {
-                      i < array.length - 1
+                      i < note.files.size - 1
                         ? <br />
                         : null
                     }

--- a/src/components/NoteView.tsx
+++ b/src/components/NoteView.tsx
@@ -328,11 +328,11 @@ const NoteView = ({ slug }: NoteViewProps) => {
           displayedSlugAliases={displayedSlugAliases}
           setDisplayedSlugAliases={setDisplayedSlugAliases}
           handleEditorContentChange={handleEditorContentChange}
-          addFilesToNoteObject={(files: FileInfo[]): void => {
+          addFilesToNoteObject={(files: Set<FileInfo>): void => {
             setActiveNote((previousState) => {
               return {
                 ...previousState,
-                files: [...previousState.files, ...files],
+                files: new Set([...previousState.files, ...files]),
               };
             });
           }}

--- a/src/hooks/useActiveNote.tsx
+++ b/src/hooks/useActiveNote.tsx
@@ -205,7 +205,7 @@ export default (
       isUnsaved: true,
       initialContent: parsedNote.content,
       flags: [...parsedNote.meta.flags, "IMPORTED"],
-      files: [],
+      files: new Set(),
     };
     setActiveNote(newActiveNote);
     // If the user does not change the slug input, we let the app

--- a/src/lib/notes/index.spec.ts
+++ b/src/lib/notes/index.spec.ts
@@ -1772,8 +1772,10 @@ describe("Notes module", () => {
         "Note 1 with slashlink to /files/a-renamed.txt",
       );
 
-      expect(note1.files.length).toBe(1);
-      expect(note1.files[0].slug).toBe("files/a-renamed.txt");
+      expect(note1.files.size).toBe(1);
+      expect(
+        note1.files.values().next().value!.slug,
+      ).toBe("files/a-renamed.txt");
     },
   );
 
@@ -1811,8 +1813,10 @@ describe("Notes module", () => {
         "Note 1 with slashlink to /files/a-renamed.txt",
       );
 
-      expect(note1.files.length).toBe(1);
-      expect(note1.files[0].slug).toBe("files/a-renamed.txt");
+      expect(note1.files.size).toBe(1);
+      expect(
+        note1.files.values().next().value!.slug,
+      ).toBe("files/a-renamed.txt");
     },
   );
 
@@ -2337,6 +2341,47 @@ describe("Notes module", () => {
       );
 
       expect(updatedFileInfo.filename).toBe("new-name.txt");
+    },
+  );
+
+
+  it(
+    "a file mounted twice in a note should only be returned once in note files",
+    async () => {
+      const notesProvider = new NotesProvider(new MockStorageProvider());
+
+      const readable = getNewTestFileReadable("foobar");
+
+      const fileInfo = await notesProvider.addFile(
+        readable,
+        "files",
+        "a.txt",
+      );
+
+      expect(fileInfo.slug).toBe("files/a.txt");
+
+      const noteSaveRequest: NoteSaveRequest = {
+        note: {
+          content: `Note 1 with two references to the same file
+          /files/a.txt
+          /files/a.txt`,
+          meta: {
+            additionalHeaders: {},
+            flags: [],
+          },
+        },
+        aliases: new Set(),
+        changeSlugTo: "note-1",
+      };
+
+      await notesProvider.put(noteSaveRequest);
+
+      const note1 = await notesProvider.get("note-1");
+
+      expect(note1.files.size).toBe(1);
+      expect(
+        note1.files.values().next().value!.slug,
+      ).toBe("files/a.txt");
     },
   );
 });

--- a/src/lib/notes/noteUtils.ts
+++ b/src/lib/notes/noteUtils.ts
@@ -384,23 +384,28 @@ const getAllInlineSpans = (blocks: Block[]): Span[] => {
 };
 
 
-const getFileSlugsReferencedInNote = (graph: Graph, noteSlug: Slug): Slug[] => {
+const getFileSlugsReferencedInNote = (
+  graph: Graph,
+  noteSlug: Slug,
+): Set<Slug> => {
   const blocks: Block[]
     = graph.indexes.blocks.get(noteSlug) as Block[];
   const allInlineSpans = getAllInlineSpans(blocks);
-  const allUsedSlugs = getSlugsFromInlineText(allInlineSpans);
-  return allUsedSlugs.filter(s => graph.files.has(s));
+  const allReferencedSlugs = getSlugsFromInlineText(allInlineSpans);
+  return new Set(allReferencedSlugs.filter(s => graph.files.has(s)));
 };
 
 
 const getFileInfosForFilesLinkedInNote = (
   graph: Graph,
   slugOfNote: Slug,
-): FileInfo[] => {
-  return getFileSlugsReferencedInNote(graph, slugOfNote)
-    // we can make a non-null assertion because getFileSlugsInNote
-    // only returns file slugs in use
-    .map((fileSlug: Slug) => graph.files.get(fileSlug)!);
+): Set<FileInfo> => {
+  const fileSlugs = getFileSlugsReferencedInNote(graph, slugOfNote);
+  // we can make a non-null assertion because getFileSlugsInNote
+  // only returns file slugs in use
+  return new Set(
+    fileSlugs.values().map((fileSlug: Slug) => graph.files.get(fileSlug)!),
+  );
 };
 
 
@@ -515,7 +520,7 @@ const getNoteFeatures = (
 
 
 const getNumberOfFiles = (graph: Graph, noteSlug: Slug): number => {
-  return getFileSlugsReferencedInNote(graph, noteSlug).length;
+  return getFileSlugsReferencedInNote(graph, noteSlug).size;
 };
 
 

--- a/src/lib/notes/searchUtils.ts
+++ b/src/lib/notes/searchUtils.ts
@@ -124,7 +124,7 @@ const getNotesWithFile = (
 ): ExistingNote[] => {
   return notes.filter((note: ExistingNote) => {
     const fileSlugs = getFileSlugsReferencedInNote(graph, note.meta.slug);
-    return fileSlugs.includes(fileSlug);
+    return fileSlugs.has(fileSlug);
   });
 };
 
@@ -233,7 +233,7 @@ const getNotesWithMediaTypes = (
       .filter((note: ExistingNote): boolean => {
         const files = getFileInfosForFilesLinkedInNote(graph, note.meta.slug);
         const includedMediaTypes = new Set(
-          files
+          files.values()
             .map((file) => getMediaTypeFromFilename(file.filename)),
         );
 
@@ -245,6 +245,7 @@ const getNotesWithMediaTypes = (
         const files = getFileInfosForFilesLinkedInNote(graph, note.meta.slug);
         const includedMediaTypes = new Set(
           files
+            .values()
             .map((file) => getMediaTypeFromFilename(file.filename)),
         );
 

--- a/src/lib/notes/types/NoteToTransmit.ts
+++ b/src/lib/notes/types/NoteToTransmit.ts
@@ -6,7 +6,7 @@ import NotePreview from "./NotePreview.js";
 export default interface NoteToTransmit extends ExistingNote {
   readonly backlinks: SparseNoteInfo[],
   readonly outgoingLinks: NotePreview[],
-  readonly files: FileInfo[],
+  readonly files: Set<FileInfo>,
   readonly numberOfCharacters: number,
   readonly numberOfBlocks: number,
   readonly aliases: Set<string>,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -37,7 +37,7 @@ const getNewNoteObject = (params: CreateNewNoteParams): UnsavedActiveNote => {
     initialContent: params.content ?? Config.DEFAULT_NOTE_CONTENT,
     // Note may already have files, but the files list will be populated by
     // notesProvider
-    files: [],
+    files: new Set(),
     flags: [],
   };
 

--- a/src/types/ActiveNote.tsx
+++ b/src/types/ActiveNote.tsx
@@ -5,7 +5,7 @@ import SparseNoteInfo from "../lib/notes/types/SparseNoteInfo";
 
 interface BaseActiveNote {
   initialContent: string,
-  files: FileInfo[],
+  files: Set<FileInfo>,
   flags: string[],
 }
 


### PR DESCRIPTION
We switch from using a Set to an Array for NoteToTransmit.files